### PR TITLE
Fix js cdn url and upgrade checkout action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: mymindstorm/setup-emsdk@v11

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ class SfizzApp {
 
   _setupEditor() {
     this._editor = ace.edit("editor");
-    ace.config.set('basePath', 'https://pagecdn.io/lib/ace/1.4.12/')
+    ace.config.set('basePath', 'https://cdn.jsdelivr.net/npm/ace-builds@1.14.0/src/')
     this._editor.setKeyboardHandler("ace/keyboard/sublime");
     this._editor.commands.addCommand({
       name: 'reload',


### PR DESCRIPTION
- PageCDN no longer works, switch to use jsdelivr as JavaScript CDN
- Update GitHub action to use newer version